### PR TITLE
feat(facebook-integration): update tokens and convert page_id to string

### DIFF
--- a/app/api--auth.php
+++ b/app/api--auth.php
@@ -11,6 +11,8 @@ require_once __DIR__ . '/models/SkOfficial.php';
 require_once __DIR__ . '/models/Barangay.php';
 require_once __DIR__ . '/models/AuthorizedAccount.php';
 require_once __DIR__ . '/models/PasswordResets.php';
+require_once __DIR__ . '/models/BarangayFacebookPages.php';
+require_once __DIR__ . '/models/FacebookPageTokens.php';
 require_once __DIR__ . '/helpers/Mailer.php';
 
 /** Check Guard Constant */
@@ -120,8 +122,6 @@ if ($action === 'process-google')
     $user = $provider->getResourceOwner($token);
     $data = $user->toArray();
 
-    print_r($data);
-
     // Extract user info
     $facebookId = $user->getId();
     $email = $data['email'] ?? null;
@@ -198,7 +198,7 @@ else if ($action === 'process-facebook')
         'code' => $_POST['code']
     ]);
 
-    // 4. Exchange for long-lived token
+    // 4. Exchange for long-lived token and get expiry of the Token
     $exchangeUrl = "https://graph.facebook.com/v24.0/oauth/access_token?" .
     "grant_type=fb_exchange_token" .
     "&client_id={$appId}" .
@@ -207,72 +207,91 @@ else if ($action === 'process-facebook')
 
     $response = file_get_contents($exchangeUrl);
     $longLivedToken = json_decode($response, true);
+    $accessToken = $longLivedToken['access_token'];
     
     $expiryTokenUrl = "https://graph.facebook.com/v24.0/debug_token?" . "input_token={$longLivedToken['access_token']}&access_token={$appId}|{$appSecret}";
     $expiryResponse = file_get_contents($expiryTokenUrl);
     $expiry = json_decode($expiryResponse, true);
-    print_r(date('Y-m-d H:i:s' ,$expiry['data']['data_access_expires_at']));
-
-    // TEST 1: Get Pages
-    $accessToken = $longLivedToken['access_token'];
-    $pagesUrl = "https://graph.facebook.com/v24.0/me/accounts?access_token=$accessToken";
-    $pages = json_decode(file_get_contents($pagesUrl), true);;
-
-
 
     $user = $provider->getResourceOwner($shortLivedToken);
     $data = $user->toArray();
 
-    // Extract user info
+    // 5. Find the Account in the Database
     $facebookId = $user->getId();
     $email = $data['email'] ?? null;
-
-    // 5. Find the Account in the Database
     $account = AuthorizedAccount::findBy('provider_user_id', $facebookId);
 
     if(!$account) {
         returnError("This Facebook Account is not Authorized. Please contact the developer if you want to be authorized. Thank you :>", 400);
     }
 
-    // Set the long-lived access token
+    // 6. Set the long-lived access token and Expiry
     $account->setAccessToken($accessToken);
     $account->setTokenExpiry(date('Y-m-d H:i:s' ,$expiry['data']['data_access_expires_at']));
     $account->update();
     
 
-    $barangay = $account->getBarangay();
+    // TEST 1: Get Pages
+    $pagesUrl = "https://graph.facebook.com/v24.0/me/accounts?access_token=$accessToken";
+    $pages = json_decode(file_get_contents($pagesUrl), true);
 
-    // 6. Issue your own JWT/cookie
-    if($account) {
-        $date   = new DateTimeImmutable();
+    // Todo:: Filter out facebook pages that is in you business portfolio
+
+    
+    // Find the Barangay Facebook Page in the Database (only assumming that the client only has one Facebook Page)
+    $barangayFacebookPage = BarangayFacebookPages::findBy('barangay_id', $account->getBarangayId());
+
+
+    if ($barangayFacebookPage) {
+        // Compare the Page IDs
+        if ($pages['data'][0]['id'] === $barangayFacebookPage->getPageId()) {
+            // Page IDs match
+
+            // Find the the page access token that is under the barangay_page and authorized_account
+            $facebookPageToken = FacebookPageTokens::findByComposite([
+                'authorized_account_id' => $account->getId(),
+                'barangay_facebook_page_id' => $barangayFacebookPage->getId()
+            ]);
+
+            $facebookPageToken->setPageAccessToken($pages['data'][0]['access_token']);
+            $facebookPageToken->update();
+        } else {
+            // Page IDs do not match
+            echo "Facebook Page ID does not match the stored Barangay Facebook Page ID.";
+        }
+    } else {
+        
+        // If no barangay facebook page found then 
+        // Check if the facebook page is in business portfolio and a true facebook page of the barangay of the authorized account
+        // Then create a row of that barangay_facebook_page of that barangay
+    }
+    
+    // 7. Issue your own JWT/cookie
+    $barangay = $account->getBarangay();
+    if ($account) {
+        $date = new DateTimeImmutable();
         $expire_at = $date->modify('+4 week')->getTimestamp();
+
         $request_data = [
-            'iss'  => 'localhost.youth',                    // Issuer
-            'exp'  => $expire_at,                           // Expire
+            'iss' => 'localhost.youth',   // Issuer
+            'exp' => $expire_at,          // Expiration
             'barangayId' => $barangay->getId(),
-            'barangayName' => $barangay->getName(),  
-            'barangayUsername' => $barangay->getUsername()                  
+            'barangayName' => $barangay->getName(),
+            'barangayUsername' => $barangay->getUsername(),
+            'provider' => 'facebook',     // Optional: if you also support Google
+            'fb_user_id' => $facebookId   // 👈 Add this field
         ];
 
-        // Create the Token
-        $jwt = JWT::encode($request_data, $GLOBALS['secret_key'], 'HS256');      
+        $jwt = JWT::encode($request_data, $GLOBALS['secret_key'], 'HS256');
 
-        // Create and Set the JWT Cookie
-        setcookie(
-            "jwt",
-            $jwt,
-            [
-                "path" => "/",
-                // Set this to true in production
-                "secure" => false,     // only HTTPS
-                "httponly" => true,   // JavaScript can’t read it
-                "samesite" => "Strict"
-            ]
-        );
-
-
+        setcookie("jwt", $jwt, [
+            "path" => "/",
+            "secure" => false,     // set true in production (HTTPS)
+            "httponly" => true,
+            "samesite" => "Strict"
+        ]);
         returnSuccess([
-            'barangay' => $barangay->getAssoc(true),
+            'barangay' => $barangay->getAssoc()
         ]);
     }
 }

--- a/app/models/BarangayFacebookPages.php
+++ b/app/models/BarangayFacebookPages.php
@@ -63,7 +63,7 @@ class BarangayFacebookPages extends Model
             (`barangay_id`, `page_id`, `page_name`)
             VALUES (?, ?, ?)
         ");
-        $stmt->bind_param("iis",
+        $stmt->bind_param("iss",
             $this->barangay_id,
             $this->page_id,
             $this->page_name,
@@ -87,7 +87,7 @@ class BarangayFacebookPages extends Model
             SET `barangay_id` = ?, `page_id` = ?, `page_name` = ?
             WHERE `id` = ?
         ");
-        $stmt->bind_param("iisi",
+        $stmt->bind_param("issi",
             $this->barangay_id,
             $this->page_id,
             $this->page_name,

--- a/app/models/FacebookPageTokens.php
+++ b/app/models/FacebookPageTokens.php
@@ -5,13 +5,12 @@ class FacebookPageTokens extends Model
 {
     protected static $table = 'facebook_page_tokens';
     public    static $table_columns = [];
-    protected static $basic_columns = ['id', 'authorized_account_id', 'barangay_facebook_page_id', 'page_access_token', 'token_expiry'];
+    protected static $basic_columns = ['id', 'authorized_account_id', 'barangay_facebook_page_id', 'page_access_token'];
 
     /** properties */
     protected $authorized_account_id = 0;
     protected $barangay_facebook_page_id = 0;
     protected $page_access_token = '';
-    protected $token_expiry = '';
 
     /**
      * Constructor
@@ -37,13 +36,12 @@ class FacebookPageTokens extends Model
     public function getAuthorizedAccountId() { return $this->authorized_account_id; }
     public function getBarangayFacebookPageId() {return $this->barangay_facebook_page_id;}
     public function getPageAccessToken() {return $this->page_access_token;}
-    public function getTokenExpiry()    { return $this->token_expiry; }
+
 
     // -------------------- SETTERS --------------------
     public function setAuthorizedAccountId($authorized_account_id) { $this->authorized_account_id = $authorized_account_id; }
     public function setBarangayFacebookPageId($barangay_facebook_page_id) {$this->barangay_facebook_page_id = $barangay_facebook_page_id;}
     public function setPageAccessToken($page_access_token) { $this->page_access_token = $page_access_token; }
-    public function setTokenExpiry($token_expiry)    { $this->token_expiry = $token_expiry; }
 
 
 
@@ -57,14 +55,13 @@ class FacebookPageTokens extends Model
     {
         $stmt = $this->getConnection()->prepare("
             INSERT INTO `" . self::$table . "`
-            (`authorized_account_id`, `barangay_facebook_page_id`, `page_access_token`, `token_expiry`)
-            VALUES (?, ?, ?, ?)
+            (`authorized_account_id`, `barangay_facebook_page_id`, `page_access_token`)
+            VALUES (?, ?, ?)
         ");
-        $stmt->bind_param("iiss",
+        $stmt->bind_param("iis",
             $this->authorized_account_id,
             $this->barangay_facebook_page_id,
             $this->page_access_token,
-            $this->token_expiry
         );
         $stmt->execute();
 
@@ -82,14 +79,13 @@ class FacebookPageTokens extends Model
     {
         $stmt = $this->getConnection()->prepare("
             UPDATE `" . self::$table . "`
-            SET `authorized_account_id` = ?, `barangay_facebook_page_id` = ?, `page_access_token` = ?, `token_expiry` = ?
+            SET `authorized_account_id` = ?, `barangay_facebook_page_id` = ?, `page_access_token` = ?
             WHERE `id` = ?
         ");
-        $stmt->bind_param("iissi",
+        $stmt->bind_param("iisi",
             $this->authorized_account_id,
             $this->barangay_facebook_page_id,
             $this->page_access_token,
-            $this->token_expiry,
             $this->id
         );
         $stmt->execute();
@@ -134,5 +130,45 @@ class FacebookPageTokens extends Model
             $pages[] = $row;
         }
         return $pages;
+    }
+
+
+
+
+    // -------------------- UTILIY METHODS --------------------
+    public static function findByComposite(array $conditions): ?FacebookPageTokens
+    {
+        $query = "SELECT * FROM `" . self::$table . "` WHERE ";
+        $params = [];
+        $types = '';
+        $clauses = [];
+
+        foreach ($conditions as $column => $value) {
+            $clauses[] = "`$column` = ?";
+
+            if (is_int($value)) {
+                $types .= 'i';
+            } elseif (is_double($value)) {
+                $types .= 'd';
+            } else {
+                $types .= 's';
+            }
+            $params[] = $value;
+        }
+
+        $query .= implode(' AND ', $clauses);
+        $stmt = self::getConnectionStatic()->prepare($query);
+        $stmt->bind_param($types, ...$params);
+        $stmt->execute();
+        $result = $stmt->get_result();
+
+        if ($result->num_rows > 0) {
+            $row = $result->fetch_assoc();
+            $token = new FacebookPageTokens();
+            $token->hydrate($row);
+            return $token;
+        }
+
+        return null;
     }
 }

--- a/youth.sql
+++ b/youth.sql
@@ -3,7 +3,7 @@
 -- https://www.phpmyadmin.net/
 --
 -- Host: 127.0.0.1
--- Generation Time: Oct 29, 2025 at 07:39 AM
+-- Generation Time: Oct 29, 2025 at 08:51 AM
 -- Server version: 10.4.32-MariaDB
 -- PHP Version: 8.2.12
 
@@ -233,7 +233,7 @@ CREATE TABLE `authorized_accounts` (
 
 INSERT INTO `authorized_accounts` (`id`, `barangay_id`, `provider`, `provider_user_id`, `email`, `name`, `picture`, `access_token`, `refresh_token`, `token_expiry`, `created_at`, `updated_at`) VALUES
 (1, 1, 'google', '111974584167448821561', 'chatgpt4youth@gmail.com', 'Youth', 'https://lh3.googleusercontent.com/a/ACg8ocJkwM7_lMqhDwgYaoVtWP8DsooJwj6YBYWgLOK39C7NAQDA7nE=s96-c', '', '', NULL, '2025-09-18 08:45:21', '2025-10-09 02:57:02'),
-(3, 1, 'facebook', '122108195955031929', 'chatgpt4youth@gmail.com', 'Youthy Hubby', 'https://platform-lookaside.fbsbx.com/platform/profilepic/?asid=122105131749031929&height=200&width=200&ext=1762438450&hash=AT9Us56bcMgwSTKIFDyutLzC', 'EAAljHlwfLMEBPwjr3AmaKahQrpPH73puH7oVwjBYxiD1vpDupDka2AcoErD37BIyV22u0HGVpZAgr5PSAqQQ0DTXiH1ZCtJkm3z2xe70UbZACGDJl6qeDYYfvI1T8BRZAH3TwsQbh4Dp8CF5OPTBwc7cDP9SE3upzSOkO17Che7ZBKqNl3E7LeGvrImA4QwwieJeFhSRHSB6rZB6zy', '', '2026-01-27 06:37:45', '2025-10-07 14:18:17', '2025-10-29 06:37:49');
+(3, 1, 'facebook', '122108195955031929', 'chatgpt4youth@gmail.com', 'Youthy Hubby', 'https://platform-lookaside.fbsbx.com/platform/profilepic/?asid=122105131749031929&height=200&width=200&ext=1762438450&hash=AT9Us56bcMgwSTKIFDyutLzC', 'EAAljHlwfLMEBP3w4S4h1jDegkEFnEQMZC7Asgi3bHXQO7NzcVr8aFGRdWE8vfPLzueQLWZAToqs9Ez9Mpd5bRvqDv2M0VRfmMoK4cbRp1C4FsA1uNr0SCrTzGjfN0pLYATKq4On93892YQC2ec9JnZAfvkC5Ki1AsfU8uaYcESdrUXd2A1aFL1cBBMeG1cGUn3rCJfTXSHzoCXO', '', '2026-01-27 07:43:50', '2025-10-07 14:18:17', '2025-10-29 07:43:56');
 
 -- --------------------------------------------------------
 
@@ -380,7 +380,6 @@ CREATE TABLE `facebook_page_tokens` (
   `authorized_account_id` int(11) NOT NULL,
   `barangay_facebook_page_id` int(11) NOT NULL,
   `page_access_token` text NOT NULL,
-  `token_expiry` timestamp NOT NULL DEFAULT current_timestamp() ON UPDATE current_timestamp(),
   `created_at` timestamp NOT NULL DEFAULT current_timestamp(),
   `updated_at` timestamp NOT NULL DEFAULT current_timestamp() ON UPDATE current_timestamp()
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
@@ -389,9 +388,9 @@ CREATE TABLE `facebook_page_tokens` (
 -- Dumping data for table `facebook_page_tokens`
 --
 
-INSERT INTO `facebook_page_tokens` (`id`, `authorized_account_id`, `barangay_facebook_page_id`, `page_access_token`, `token_expiry`, `created_at`, `updated_at`) VALUES
-(1, 3, 1, 'EAAljHlwfLMEBP3QeQVBbLyYbU7yb3xOxqDESedvBZAIwg0dmzIQDzCKAehRWnTMysZC4jFvXbBeyXpsGeoXDvlGdf5r8GE5cbg3KPZCEq6EZA8AjV5oZAAvuaNQTZCQ9ebLhTGw21TuVtnGeYL0yaOBRY9fYrBTUuUrL2shZCNgZAZAZCNPf1wuQg2KsSpvK7b6y9kbbzZAbAkn4o90T9A1ezHo13ke', '2025-10-27 22:54:25', '2025-10-28 05:56:02', '2025-10-28 05:56:02'),
-(7, 1, 24, 'EAAGm0PX4ZCpsBAKZCZA...UPDATED', '2025-12-31 15:59:59', '2025-10-28 14:38:19', '2025-10-28 14:38:19');
+INSERT INTO `facebook_page_tokens` (`id`, `authorized_account_id`, `barangay_facebook_page_id`, `page_access_token`, `created_at`, `updated_at`) VALUES
+(1, 3, 1, 'EAAljHlwfLMEBP6H6Drm4sKiZBLljZCjVfjUQnB9pgPZBgMZCZBck8vDOzcGrPp5VkjMch3jKBkzdiHEVIYhLLU0jUyuZAKGZCyeiR3TgneumdWT0E79UV4RvAspRkxQjmZB67wrVnSZBpZCG32zvu5L9NHZARpmHGPcJHvr4GM7AsZCZA3X5ITgDqphRsG4wHrg1REJkoij6uNRMZBqBqAETlqjAJM', '2025-10-28 05:56:02', '2025-10-29 07:43:56'),
+(7, 1, 24, 'EAAGm0PX4ZCpsBAKZCZA...UPDATED', '2025-10-28 14:38:19', '2025-10-28 14:38:19');
 
 -- --------------------------------------------------------
 

--- a/youth.sql
+++ b/youth.sql
@@ -3,7 +3,7 @@
 -- https://www.phpmyadmin.net/
 --
 -- Host: 127.0.0.1
--- Generation Time: Oct 28, 2025 at 04:16 PM
+-- Generation Time: Oct 29, 2025 at 07:39 AM
 -- Server version: 10.4.32-MariaDB
 -- PHP Version: 8.2.12
 
@@ -233,7 +233,7 @@ CREATE TABLE `authorized_accounts` (
 
 INSERT INTO `authorized_accounts` (`id`, `barangay_id`, `provider`, `provider_user_id`, `email`, `name`, `picture`, `access_token`, `refresh_token`, `token_expiry`, `created_at`, `updated_at`) VALUES
 (1, 1, 'google', '111974584167448821561', 'chatgpt4youth@gmail.com', 'Youth', 'https://lh3.googleusercontent.com/a/ACg8ocJkwM7_lMqhDwgYaoVtWP8DsooJwj6YBYWgLOK39C7NAQDA7nE=s96-c', '', '', NULL, '2025-09-18 08:45:21', '2025-10-09 02:57:02'),
-(3, 1, 'facebook', '122108195955031929', 'chatgpt4youth@gmail.com', 'Youthy Hubby', 'https://platform-lookaside.fbsbx.com/platform/profilepic/?asid=122105131749031929&height=200&width=200&ext=1762438450&hash=AT9Us56bcMgwSTKIFDyutLzC', 'EAAljHlwfLMEBP6A09oI5mv77ZAjIPP26DqSgHZC1Rhla0LErZAOi0VWK9YYOte9ksCjqQIZCdm6ZCxXAWYFb9bd6Pw9bjWHxTuHF56SYSO1BGWdHuSsosWFjMISPEcm64uUHp4gVKGQT41tL8wMZBQ0J2cISlUGRZA6SpGcE6GmovVEzrRW7h7Xa3BpLkN0vpQ9v6th3ZASdeQZCx', '', '2026-01-26 05:52:54', '2025-10-07 14:18:17', '2025-10-28 05:52:56');
+(3, 1, 'facebook', '122108195955031929', 'chatgpt4youth@gmail.com', 'Youthy Hubby', 'https://platform-lookaside.fbsbx.com/platform/profilepic/?asid=122105131749031929&height=200&width=200&ext=1762438450&hash=AT9Us56bcMgwSTKIFDyutLzC', 'EAAljHlwfLMEBPwjr3AmaKahQrpPH73puH7oVwjBYxiD1vpDupDka2AcoErD37BIyV22u0HGVpZAgr5PSAqQQ0DTXiH1ZCtJkm3z2xe70UbZACGDJl6qeDYYfvI1T8BRZAH3TwsQbh4Dp8CF5OPTBwc7cDP9SE3upzSOkO17Che7ZBKqNl3E7LeGvrImA4QwwieJeFhSRHSB6rZB6zy', '', '2026-01-27 06:37:45', '2025-10-07 14:18:17', '2025-10-29 06:37:49');
 
 -- --------------------------------------------------------
 
@@ -306,7 +306,7 @@ INSERT INTO `barangays` (`id`, `cluster_id`, `slug`, `name`, `img`, `sk_barangay
 CREATE TABLE `barangay_facebook_pages` (
   `id` int(11) NOT NULL,
   `barangay_id` int(11) NOT NULL,
-  `page_id` bigint(20) NOT NULL,
+  `page_id` text NOT NULL,
   `page_name` varchar(255) NOT NULL,
   `created_at` timestamp NOT NULL DEFAULT current_timestamp(),
   `updated_at` timestamp NOT NULL DEFAULT current_timestamp() ON UPDATE current_timestamp()
@@ -317,8 +317,8 @@ CREATE TABLE `barangay_facebook_pages` (
 --
 
 INSERT INTO `barangay_facebook_pages` (`id`, `barangay_id`, `page_id`, `page_name`, `created_at`, `updated_at`) VALUES
-(1, 1, 851109194751372, 'Youth Oriented Unified Transparency Hub Testing - Page', '2025-10-28 05:53:53', '2025-10-28 05:53:53'),
-(24, 2, 1234567890, 'Updated Page Name', '2025-10-28 06:50:15', '2025-10-28 06:58:09');
+(1, 1, '851109194751372', 'Youth Oriented Unified Transparency Hub Testing - Page', '2025-10-28 05:53:53', '2025-10-28 05:53:53'),
+(24, 2, '1234567890', 'Updated Page Name', '2025-10-28 06:50:15', '2025-10-28 06:58:09');
 
 -- --------------------------------------------------------
 


### PR DESCRIPTION
Converted page_id in barangay Facebook pages from int to string

Removed token expiry logic for FacebookPageTokens

Updated api-auth.php for cross-site posting

After Facebook login, updates both user_access_token and page_access_token in the database

JWT from Youth website now includes the fbuserid